### PR TITLE
Fixes "Page" column in TOC

### DIFF
--- a/ucithesis.cls
+++ b/ucithesis.cls
@@ -193,10 +193,10 @@
 
 % Add "Page" as column title to Table of Contents, List of Figures,
 % List of Tables, and List of Algorithms
-\addtocontents{toc}{\protect\raggedleft Page\\}
-\addtocontents{lof}{\protect\raggedleft Page\\}
-\addtocontents{lot}{\protect\raggedleft Page\\}
-\addtocontents{loa}{\protect\raggedleft Page\\}
+\addtocontents{toc}{{\protect\flushright Page\par}}
+\addtocontents{lof}{{\protect\flushright Page\par}}
+\addtocontents{lot}{{\protect\flushright Page\par}}
+\addtocontents{loa}{{\protect\flushright Page\par}}
 
 \newcommand{\preliminarypages}
 {


### PR DESCRIPTION
Chapter titles that span more than one line in the TOC are now left-aligned rather than ragged left.
Fixes #17 