### PR TITLE
Fix for hyperref warning.

### DIFF
--- a/ucithesis.cls
+++ b/ucithesis.cls
@@ -252,7 +252,7 @@
 	  \clearpage
 	\fi
 	\phantomsection
-	\addcontentsline{toc}{chapter}{ABSTRACT OF THE \uppercase{\Documenttitle}}
+	\addcontentsline{toc}{chapter}{ABSTRACT OF THE \texorpdfstring{\uppercase{\Documenttitle}}{DISSERTATION}}
 	\abstractpage
 	\clearpage
 	\setcounter{page}{1}


### PR DESCRIPTION
Use of the `texorpdfstrong{}{}` macro resolves the triggering of the hyperref "Token not allowed in a PDF string" warning by the use of `\uppercase{}`.